### PR TITLE
Add option to export unfiltered dataset for filtered layers

### DIFF
--- a/geopacker_algorithm.py
+++ b/geopacker_algorithm.py
@@ -20,6 +20,7 @@ class GeopackerAlgorithm(QgsProcessingAlgorithm):
     STRIP_EMPTY = 'STRIP_EMPTY'
     SKIP_REMOTE = 'SKIP_REMOTE'
     ONLY_SELECTED = 'ONLY_SELECTED'
+    EXPORT_UNFILTERED = 'EXPORT_UNFILTERED'
     GROUP_GPKGS = 'GROUP_GPKGS'
 
     def tr(self, string):
@@ -88,6 +89,14 @@ class GeopackerAlgorithm(QgsProcessingAlgorithm):
 
         self.addParameter(
             QgsProcessingParameterBoolean(
+                self.EXPORT_UNFILTERED,
+                self.tr('Export unfiltered data for filtered layers'),
+                defaultValue=False
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterBoolean(
                 self.GROUP_GPKGS,
                 self.tr('Group GPKGs by their Layer Tree hierarchy'),
                 defaultValue=False
@@ -116,6 +125,7 @@ class GeopackerAlgorithm(QgsProcessingAlgorithm):
         strip_empty = self.parameterAsBool(parameters, self.STRIP_EMPTY, context)
         skip_remote = self.parameterAsBool(parameters, self.SKIP_REMOTE, context)
         only_selected = self.parameterAsBool(parameters, self.ONLY_SELECTED, context)
+        export_unfiltered = self.parameterAsBool(parameters, self.EXPORT_UNFILTERED, context)
         group_gpkgs = self.parameterAsBool(parameters, self.GROUP_GPKGS, context)
 
         # Load the project
@@ -134,6 +144,7 @@ class GeopackerAlgorithm(QgsProcessingAlgorithm):
             strip_empty=strip_empty,
             skip_remote=skip_remote,
             only_selected=only_selected,
+            export_unfiltered=export_unfiltered,
             group_gpkgs=group_gpkgs,
             project=project,
             feedback=feedback

--- a/geopacker_dialog.py
+++ b/geopacker_dialog.py
@@ -21,6 +21,8 @@ class GeopackerDialog(QDialog, FORM_CLASS):
         self.chkStripEmpty.toggled.connect(self._update_estimate)
         self.chkSkipRemoteVectors.toggled.connect(self._update_estimate)
         self.chkOnlySelected.toggled.connect(self._update_estimate)
+        self.chkGroupGpkgs.toggled.connect(self._update_estimate)
+        self.chkExportUnfiltered.toggled.connect(self._update_estimate)
 
     # ------------------------------------------------------------------ #
     #  Estimated Output Size                                               #
@@ -40,6 +42,7 @@ class GeopackerDialog(QDialog, FORM_CLASS):
                 strip_empty=self.chkStripEmpty.isChecked(),
                 skip_remote=self.chkSkipRemoteVectors.isChecked(),
                 only_selected=self.chkOnlySelected.isChecked(),
+                export_unfiltered=self.chkExportUnfiltered.isChecked(),
             )
         except Exception as e:
             from qgis.core import QgsMessageLog, Qgis
@@ -106,6 +109,7 @@ class GeopackerDialog(QDialog, FORM_CLASS):
         strip_empty = self.chkStripEmpty.isChecked()
         skip_remote = self.chkSkipRemoteVectors.isChecked()
         only_selected = self.chkOnlySelected.isChecked()
+        export_unfiltered = self.chkExportUnfiltered.isChecked()
         group_gpkgs = self.chkGroupGpkgs.isChecked()
         
         if not output_file:
@@ -119,6 +123,7 @@ class GeopackerDialog(QDialog, FORM_CLASS):
             strip_empty=strip_empty,
             skip_remote=skip_remote,
             only_selected=only_selected,
+            export_unfiltered=export_unfiltered,
             group_gpkgs=group_gpkgs,
             progress_bar=self.progressBar,
             status_label=self.lblStatus

--- a/geopacker_dialog_base.ui
+++ b/geopacker_dialog_base.ui
@@ -82,6 +82,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="chkExportUnfiltered">
+     <property name="text">
+      <string>Export unfiltered data for filtered layers</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="lblEstimatedSize">
        <property name="text">
         <string>Estimated Output Size: —</string>

--- a/packaging_logic.py
+++ b/packaging_logic.py
@@ -28,12 +28,13 @@ def _safe_file_size(path):
         return 0
 
 class GeopackerLogic:
-    def __init__(self, output_file, strip_duplicates=True, strip_empty=True, skip_remote=True, only_selected=False, group_gpkgs=False, progress_bar=None, status_label=None, project=None, feedback=None):
+    def __init__(self, output_file, strip_duplicates=True, strip_empty=True, skip_remote=True, only_selected=False, export_unfiltered=False, group_gpkgs=False, progress_bar=None, status_label=None, project=None, feedback=None):
         self.output_file = output_file
         self.strip_duplicates = strip_duplicates
         self.strip_empty = strip_empty
         self.skip_remote = skip_remote
         self.only_selected = only_selected
+        self.export_unfiltered = export_unfiltered
         self.group_gpkgs = group_gpkgs
         self.progress_bar = progress_bar
         self.status_label = status_label
@@ -339,8 +340,18 @@ class GeopackerLogic:
                     if os.path.exists(target_gpkg):
                         options.actionOnExistingFile = QgsVectorFileWriter.CreateOrOverwriteLayer
                     
-                    write_result = QgsVectorFileWriter.writeAsVectorFormatV3(
-                        layer, target_gpkg, self.project.transformContext(), options)
+                    original_subset_string = ""
+                    if self.export_unfiltered:
+                        original_subset_string = layer.subsetString()
+                        if original_subset_string:
+                            layer.setSubsetString("")
+
+                    try:
+                        write_result = QgsVectorFileWriter.writeAsVectorFormatV3(
+                            layer, target_gpkg, self.project.transformContext(), options)
+                    finally:
+                        if self.export_unfiltered and original_subset_string:
+                            layer.setSubsetString(original_subset_string)
                         
                     writer_err = write_result[0]
                     error_msg = write_result[1] if len(write_result) > 1 else str(writer_err)


### PR DESCRIPTION
Added a new UI option 'Export unfiltered data for filtered layers' that allows users to bypass subset strings (filters) while writing layer data into the exported GeoPackage. The `QgsVectorLayer` filter is temporarily removed before the export and restored immediately afterward. The exported QGIS project file retains the subset string so the layer remains filtered when opened, but all original features are preserved in the data source.
